### PR TITLE
Fix getPageLengthFromRequest with fallback value

### DIFF
--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -51,7 +51,7 @@ abstract class TweetTimelineV2Paginator<
   }
 
   protected getPageLengthFromRequest(result: TwitterResponse<TResult>) {
-    return result.data.data.length;
+    return result.data?.data?.length||0;
   }
 
   protected isFetchLastOver(result: TwitterResponse<TResult>) {


### PR DESCRIPTION
Also, we need to update `getPageLengthFromRequest` to handle for the case when `result.data.data` is undefined. So we could use optional chaining and set 0 as fallback value.

```javascript
isFetchLastOver(result) {
  return result.data?.data?.length||0;
}
```