### PR TITLE
Add conditional chaining to isFetchLastOver

### DIFF
--- a/src/paginators/tweet.paginator.v2.ts
+++ b/src/paginators/tweet.paginator.v2.ts
@@ -55,7 +55,7 @@ abstract class TweetTimelineV2Paginator<
   }
 
   protected isFetchLastOver(result: TwitterResponse<TResult>) {
-    return !result.data.data.length || !result.data.meta.next_token;
+    return !result.data?.data?.length || !result.data.meta.next_token;
   }
 
   protected getItemArray() {


### PR DESCRIPTION
We also need to update `isFetchLastOver` in the same manner.

```javascript
protected isFetchLastOver(result: TwitterResponse<TResult>) {
  return !result.data?.data?.length || !result.data.meta.next_token;
}
```